### PR TITLE
Feat ot112 65 add social media links to organizations endpoint

### DIFF
--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::OrganizationsController < ApplicationController
 
   private
     def organization_params
-      params.permit(:name, :email, :address, :about_us_text, :phone, :welcome_text, :instagram_url, :facebook_url, :linkedin_url)
+      params.permit(:name, :email, :address, :about_us_text, :phone, :welcome_text, :instagram_url, :facebook_url, :linkedin_url, :image)
     end
 
 end

--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::OrganizationsController < ApplicationController
 
   private
     def organization_params
-      params.permit(:name, :email, :adress, :about_us_text, :phone, :welcome_text, :instagram_url, :facebook_url, :linkedin_url)
+      params.permit(:name, :email, :address, :about_us_text, :phone, :welcome_text, :instagram_url, :facebook_url, :linkedin_url)
     end
 
 end

--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -17,7 +17,7 @@ class Api::V1::OrganizationsController < ApplicationController
 
   private
     def organization_params
-      params.permit(:name, :email, :address, :about_us_text, :phone, :welcome_text)
+      params.permit(:name, :email, :adress, :about_us_text, :phone, :welcome_text, :instagram_url, :facebook_url, :linkedin_url)
     end
 
 end

--- a/app/serializers/organization_serializer.rb
+++ b/app/serializers/organization_serializer.rb
@@ -18,7 +18,7 @@
 #
 class OrganizationSerializer
   include JSONAPI::Serializer
-  attributes :name, :phone, :address
+  attributes :name, :phone, :address, :instagram_url, :facebook_url, :linkedin_url
   attribute :image do |organization|
     Rails.application.routes.url_helpers.rails_blob_path(organization.image, only_path: true) if organization.image.attached?
   end


### PR DESCRIPTION
Added migration to add social media links (facebook, instagram, linkedin) to organizations table and updated controller and serializer.