### PR TITLE
Fix testimonials index and controller errors

### DIFF
--- a/app/controllers/api/v1/testimonials_controller.rb
+++ b/app/controllers/api/v1/testimonials_controller.rb
@@ -2,6 +2,11 @@ class Api::V1::TestimonialsController < ApplicationController
   before_action :set_testimonial, only: %i[update destroy]
   before_action :authorize_request
 
+  def index
+    @testimonials = Testimonial.all
+    render json: TestimonialSerializer.new(@testimonials).serializable_hash.to_json
+  end
+
   def create
     @testimonial = Testimonial.new(testimonial_params)
     if admin?(@current_user) && @testimonial.save
@@ -34,6 +39,8 @@ class Api::V1::TestimonialsController < ApplicationController
           },
           status: :ok
       end
+    end
+  end
 
 
   private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
       get 'organizations/:id/public', to: 'organizations#public'
       post 'organizations/public', to: 'organizations#create'
       resources :slides, only: %i[index show create update destroy]
-      resources :testimonials, only: %i[create update destroy]
+      resources :testimonials, only: %i[index create update destroy]
       resources :users, only: %i[index update destroy]
     end
   end


### PR DESCRIPTION
Éste endpoint no estaba especificado en ningún ticket, así que se generó el fix para poder continuar con otros tickets relacionados.

A su vez, se agregaron los `end` faltantes en el destroy endpoint del mismo controlador.