### PR TITLE
Fixed duplicated method in members controller

### DIFF
--- a/app/controllers/api/v1/members_controller.rb
+++ b/app/controllers/api/v1/members_controller.rb
@@ -51,15 +51,13 @@ class Api::V1::MembersController < ApplicationController
     params.permit(:name, :facebook_url, :instagram_url, :linkedin_url)
   end
 
-  def set_member
-    @member = Member.find(params[:id])
-  rescue ActiveRecord::RecordNotFound
-    render json: { error: "Could not find member with ID '#{params[:id]}'" }
-  end
-  
   def is_integer?(p)
     p.to_i.to_s == p
   end
 
-  
+  def set_member
+    @member = Member.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: "Could not find member with ID '#{params[:id]}'"}
+  end
 end


### PR DESCRIPTION
El método set_member estaba duplicado, por lo cuál se elimina el que no rescata el error. También se agrega espaciado dentro de llaves.